### PR TITLE
Don't create database in serving command

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ a Django server in a seperate process.
    `LiveServerTestCase`.
 4. (optional) Add `externaltestserver` to `INSTALLED_APPS` to run
    `python manage.py livetestserver <port> [--static]` in another process.
+   Note: This command uses the `default` database. By default, Django will
+   create a new database for tests. You must tell Django, when running
+   this command to use the name of the test database explicitly. By default
+   the test database is just `test_<old database name>`, with the normal
+   connection settings.
 
 ## Why?
 
@@ -127,27 +132,28 @@ db:
 test:
     build: .
     # sleep because https://github.com/docker/compose/issues/374#issuecomment-156546513
-    command: bash -c "sleep 10; python manage.py test --keepdb"
+    command: bash -c "sleep 5; python manage.py test"
     links:
         - db
         - selenium
     environment:
         - EXTERNAL_TEST_SERVER=http://livetestserver:8000
         - SELENIUM_HOST=http://selenium:4444/wd/hub
+        - DATABASE_URL=postgres://postgres@db:5432/postgres
 selenium:
     image: selenium/standalone-chrome:2.48.2
     links:
         - livetestserver
 livetestserver:
     build: .
-    # sleep because https://github.com/docker/compose/issues/374#issuecomment-156546513
-    command: bash -c "sleep 10; python manage.py livetestserver 8000 --static"
+    command: python manage.py livetestserver 8000 --static
     expose:
       - "8000"
     links:
         - db
     environment:
         - PYTHONUNBUFFERED=1
+        - DATABASE_URL=postgres://postgres@db:5432/test_postgres
 
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,23 +2,24 @@ db:
     image: postgres:9.5
 test:
     build: .
-    command: bash -c "sleep 10; python manage.py test --keepdb"
+    command: bash -c "sleep 5; python manage.py test"
     links:
         - db
         - selenium
     environment:
         - EXTERNAL_TEST_SERVER=http://livetestserver:8000
         - SELENIUM_HOST=http://selenium:4444/wd/hub
-        - PYTHONUNBUFFERED=1
+        - DATABASE_URL=postgres://postgres@db:5432/postgres
 selenium:
     image: selenium/standalone-chrome:2.48.2
     links:
         - livetestserver
 livetestserver:
     build: .
-    command: bash -c "sleep 10; python manage.py livetestserver 8000 --static"
+    command: python manage.py livetestserver 8000 --static
     environment:
         - PYTHONUNBUFFERED=1
+        - DATABASE_URL=postgres://postgres@db:5432/test_postgres
     expose:
         - "8000"
     links:

--- a/externaltestserver/management/commands/livetestserver.py
+++ b/externaltestserver/management/commands/livetestserver.py
@@ -1,7 +1,6 @@
 from django.core.management.base import BaseCommand
 from django.test.testcases import LiveServerThread
 from django.contrib.staticfiles.handlers import StaticFilesHandler
-from django.test.runner import setup_databases
 
 
 class Command(BaseCommand):
@@ -19,13 +18,6 @@ class Command(BaseCommand):
             help='Transperently serve staticfiles assets')
 
     def handle(self, *args, **options):
-        self.stdout.write('Setting up test databases....')
-
-        setup_databases(
-            verbosity=0,
-            interactive=False,
-            keepdb=True,
-        )
         host = "0.0.0.0"
         port = options["port"]
         lst = LiveServerThread(

--- a/test_project/requirements.txt
+++ b/test_project/requirements.txt
@@ -1,2 +1,3 @@
 selenium==2.48.0
 psycopg2==2.6.1
+dj-database-url==0.3.0

--- a/test_project/settings.py
+++ b/test_project/settings.py
@@ -1,16 +1,9 @@
 import os
 
+import dj_database_url
+
 ROOT_URLCONF = "items.urls"
-DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.postgresql_psycopg2',
-        'NAME': 'postgres',
-        'USER': 'postgres',
-        'PASSWORD': '',
-        'HOST': 'db',
-        'PORT': '5432',
-    }
-}
+DATABASES = {'default': dj_database_url.config()}
 DEBUG = TEMPLATE_DEBUG = True
 
 EXTERNAL_TEST_SERVER = os.environ.get('EXTERNAL_TEST_SERVER', None)


### PR DESCRIPTION
Before, we were creating the database in the
`livetestserver` command. This worked, but it
meant that the `test` command had to wait
to start until `livetestserver` was done migrating
the database. If we instead move the database
setup to the `test` command, then it can
start whenever the database is setup.
